### PR TITLE
Disable remapper for higher stability

### DIFF
--- a/module/src/jni/inject.cpp
+++ b/module/src/jni/inject.cpp
@@ -69,7 +69,7 @@ void inject_lib(std::string const &lib_path, std::string const &logContext) {
     auto *handle = xdl_open(lib_path.c_str(), XDL_TRY_FORCE_LOAD);
     if (handle) {
         LOGI("%sInjected %s with handle %p", logContext.c_str(), lib_path.c_str(), handle);
-        remap_lib(lib_path);
+        /* remap_lib(lib_path); */
         return;
     }
 
@@ -78,7 +78,7 @@ void inject_lib(std::string const &lib_path, std::string const &logContext) {
     handle = dlopen(lib_path.c_str(), RTLD_NOW);
     if (handle) {
         LOGI("%sInjected %s with handle %p (dlopen)", logContext.c_str(), lib_path.c_str(), handle);
-        remap_lib(lib_path);
+        /* remap_lib(lib_path); */
         return;
     }
 


### PR DESCRIPTION
This PR disable Zygisk Frida's remote library remapping capabilities to provide high statbility during app spawning and minimize crashed.