### PR TITLE
Inject on specialize: Catch early checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ jobs:
           distribution: temurin
           java-version: 11
           cache: gradle
+      - name: Run unit tests
+        run: |
+          chmod +x ./module/src/jni/tests/run.sh
+          ./module/src/jni/tests/run.sh
+        env:
+          CXX: g++
       - name: Get Module Version
         id: module-version
         run: |

--- a/module/src/jni/config.cpp
+++ b/module/src/jni/config.cpp
@@ -102,6 +102,16 @@ static std::optional<target_config> deserialize_target_config(const rapidjson::V
     }
     result.start_up_delay_ms = start_up_delay_ms.GetUint64();
 
+    // Optional; defaults to false so existing configs are unaffected.
+    if (doc.HasMember("inject_on_specialize")) {
+        auto &inject_on_specialize = doc["inject_on_specialize"];
+        if (!inject_on_specialize.IsBool()) {
+            LOGE("invalid config: expected inject_on_specialize to be a bool");
+            return std::nullopt;
+        }
+        result.inject_on_specialize = inject_on_specialize.GetBool();
+    }
+
     auto &injected_libaries = doc["injected_libraries"];
     auto deserialized_libraries = deserialize_libraries(injected_libaries);
     if (!deserialized_libraries.has_value()) {

--- a/module/src/jni/config.cpp
+++ b/module/src/jni/config.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <sstream>
 #include <optional>
+#include <vector>
 
 #include "rapidjson/document.h"
 #include "rapidjson/istreamwrapper.h"

--- a/module/src/jni/config.h
+++ b/module/src/jni/config.h
@@ -18,6 +18,12 @@ struct target_config{
     uint64_t start_up_delay_ms;
     std::vector<std::string> injected_libraries;
     child_gating_config child_gating;
+    // When true, inject synchronously inside postAppSpecialize (before the app
+    // runs Application.onCreate) instead of waiting for process init on a
+    // detached thread. Lets the gadget's top-level hooks land before the app's
+    // first anti-tamper check. Optional; defaults to false. Safe only for
+    // script-interaction gadgets (they load their script and return).
+    bool inject_on_specialize;
 };
 
 std::optional<target_config> load_config(std::string const& module_dir, std::string const& app_name);

--- a/module/src/jni/include/riru_config.h
+++ b/module/src/jni/include/riru_config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 namespace riru_config {
-    extern const int version_code;
-    extern const char* const version_name;
-    extern const int api_version;
-}
+extern const int version_code;
+extern const char* const version_name;
+extern const int api_version;
+}  // namespace riru_config

--- a/module/src/jni/inject.cpp
+++ b/module/src/jni/inject.cpp
@@ -4,7 +4,6 @@
 
 #include <chrono>
 #include <cinttypes>
-#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -47,7 +46,7 @@ static void delay_start_up(uint64_t start_up_delay_ms) {
         return;
     }
 
-    LOGI("Waiting for configured start up delay %" PRIu64"ms", start_up_delay_ms);
+    LOGI("Waiting for configured start up delay %" PRIu64 "ms", start_up_delay_ms);
 
     int countdown = 0;
     uint64_t delay = start_up_delay_ms;
@@ -93,13 +92,26 @@ static void inject_libs(target_config const &cfg) {
     // Loading the gadget before that will freeze the process
     // before the init has completed. This make the process
     // undiscoverable or otherwise cause issue attaching.
-    wait_for_init(cfg.app_name);
+    //
+    // This concern only applies to listen-interaction gadgets (which block
+    // waiting for a client) and to frida-server discoverability. A
+    // script-interaction gadget just loads its script and returns, so targets
+    // that set inject_on_specialize skip the wait and get injected before
+    // Application.onCreate -- see check_and_inject().
+    if (!cfg.inject_on_specialize) {
+        wait_for_init(cfg.app_name);
+    }
 
     if (cfg.child_gating.enabled) {
         enable_child_gating(cfg.child_gating);
     }
 
-    delay_start_up(cfg.start_up_delay_ms);
+    // Skip the configured start-up delay on the specialize path: sleeping here would block
+    // postAppSpecialize before Application.onCreate (ANR risk) and defeats the point of injecting
+    // early. Same rationale as the wait_for_init skip above.
+    if (!cfg.inject_on_specialize) {
+        delay_start_up(cfg.start_up_delay_ms);
+    }
 
     for (auto &lib_path : cfg.injected_libraries) {
         LOGI("Injecting %s", lib_path.c_str());
@@ -118,15 +130,22 @@ bool check_and_inject(std::string const &app_name) {
     LOGI("App detected: %s", app_name.c_str());
     LOGI("PID: %d", getpid());
 
-
     auto target_config = cfg.value();
     if (!target_config.enabled) {
         LOGI("Injection disabled for %s", app_name.c_str());
         return false;
     }
 
-    std::thread inject_thread(inject_libs, target_config);
-    inject_thread.detach();
+    // When inject_on_specialize is set, inject synchronously on the Zygisk specialize thread so the
+    // dlopen completes before postAppSpecialize returns -> before handleBindApplication -> before
+    // Application.onCreate. This is what lets the gadget's top-level hooks be live before the app's
+    // first anti-tamper read, instead of racing them on a detached thread. Otherwise inject on a
+    // detached thread that first waits for process init (see inject_libs).
+    if (target_config.inject_on_specialize) {
+        inject_libs(target_config);
+    } else {
+        std::thread(inject_libs, target_config).detach();
+    }
 
     return true;
 }

--- a/module/src/jni/remapper.cpp
+++ b/module/src/jni/remapper.cpp
@@ -5,6 +5,7 @@
 
 #include <cinttypes>
 #include <cstdint>
+#include <cstdio>
 #include <string>
 #include <vector>
 

--- a/module/src/jni/tests/config_test.cpp
+++ b/module/src/jni/tests/config_test.cpp
@@ -1,0 +1,95 @@
+// Host unit tests for ZygiskFrida config parsing (no device / NDK required).
+//
+// Focus: the inject_on_specialize target option — default, true, false, and
+// invalid-type handling — plus a sanity check that the surrounding target
+// fields still parse.
+//
+// Build & run:  module/src/jni/tests/run.sh
+
+#include <sys/stat.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include "config.h"
+
+static int g_failures = 0;
+
+#define CHECK(cond, msg)                                                     \
+  do {                                                                       \
+    if (cond) {                                                             \
+      std::printf("  ok   - %s\n", msg);                                    \
+    } else {                                                                \
+      std::printf("  FAIL - %s (%s:%d)\n", msg, __FILE__, __LINE__);        \
+      ++g_failures;                                                         \
+    }                                                                       \
+  } while (0)
+
+// Minimal valid target body (everything except inject_on_specialize).
+static const char *BASE_TARGET =
+    "\"app_name\": \"com.test.app\","
+    "\"enabled\": true,"
+    "\"start_up_delay_ms\": 0,"
+    "\"injected_libraries\": [ { \"path\": \"/data/local/tmp/libknox.so\" } ]";
+
+// Create a fresh per-case temp dir and write its config.json. Returns the dir.
+static std::string write_config(const std::string &name, const std::string &body) {
+  std::string dir = "/tmp/zygfri_cfg_test_" + name;
+  mkdir(dir.c_str(), 0755);  // NOLINT — fine if it already exists
+  std::ofstream(dir + "/config.json")
+      << "{ \"targets\": [ {" << body << "} ] }";
+  return dir;
+}
+
+int main() {
+  std::printf("inject_on_specialize parsing:\n");
+
+  // 1. Absent -> defaults to false, base fields still parse.
+  {
+    auto dir = write_config("absent", BASE_TARGET);
+    auto cfg = load_config(dir, "com.test.app");
+    CHECK(cfg.has_value(), "absent: config loads");
+    CHECK(cfg && cfg->inject_on_specialize == false,
+          "absent: inject_on_specialize defaults to false");
+    CHECK(cfg && cfg->enabled && cfg->app_name == "com.test.app" &&
+              cfg->start_up_delay_ms == 0 && cfg->injected_libraries.size() == 1,
+          "absent: base target fields parsed");
+  }
+
+  // 2. Explicit true.
+  {
+    auto dir = write_config(
+        "true", std::string(BASE_TARGET) + ",\"inject_on_specialize\": true");
+    auto cfg = load_config(dir, "com.test.app");
+    CHECK(cfg.has_value(), "true: config loads");
+    CHECK(cfg && cfg->inject_on_specialize == true,
+          "true: inject_on_specialize parsed as true");
+  }
+
+  // 3. Explicit false.
+  {
+    auto dir = write_config(
+        "false", std::string(BASE_TARGET) + ",\"inject_on_specialize\": false");
+    auto cfg = load_config(dir, "com.test.app");
+    CHECK(cfg.has_value(), "false: config loads");
+    CHECK(cfg && cfg->inject_on_specialize == false,
+          "false: inject_on_specialize parsed as false");
+  }
+
+  // 4. Wrong type -> whole config rejected (no silent default).
+  {
+    auto dir = write_config(
+        "wrongtype",
+        std::string(BASE_TARGET) + ",\"inject_on_specialize\": \"yes\"");
+    auto cfg = load_config(dir, "com.test.app");
+    CHECK(!cfg.has_value(), "wrong-type: config rejected");
+  }
+
+  if (g_failures == 0) {
+    std::printf("\nALL PASSED\n");
+    return 0;
+  }
+  std::printf("\n%d FAILURE(S)\n", g_failures);
+  return 1;
+}

--- a/module/src/jni/tests/run.sh
+++ b/module/src/jni/tests/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Compile and run the host-side ZygiskFrida config unit tests.
+# No NDK/device needed: <android/log.h> is stubbed under tests/stub.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+JNI="$(cd "$HERE/.." && pwd)"
+BIN="$(mktemp -d)/config_test"
+
+"${CXX:-clang++}" -std=c++17 -Wall -Wextra \
+  -I "$HERE/stub" \
+  -isystem "$JNI/include" \
+  -I "$JNI" \
+  "$HERE/config_test.cpp" \
+  "$JNI/config.cpp" \
+  -o "$BIN"
+
+"$BIN"

--- a/module/src/jni/tests/stub/android/log.h
+++ b/module/src/jni/tests/stub/android/log.h
@@ -1,0 +1,21 @@
+// Host stub for <android/log.h> so the JNI sources can be compiled and unit
+// tested off-device (the real header ships only with the Android NDK).
+#ifndef ZYGISKFRIDA_TEST_STUB_ANDROID_LOG_H
+#define ZYGISKFRIDA_TEST_STUB_ANDROID_LOG_H
+
+enum android_LogPriority {
+  ANDROID_LOG_DEFAULT = 1,
+  ANDROID_LOG_VERBOSE = 2,
+  ANDROID_LOG_DEBUG = 3,
+  ANDROID_LOG_INFO = 4,
+  ANDROID_LOG_WARN = 5,
+  ANDROID_LOG_ERROR = 6,
+};
+
+// No-op: tests don't care about log output, only parsing behaviour.
+static inline int __android_log_print(int /*prio*/, const char * /*tag*/,
+                                      const char * /*fmt*/, ...) {
+  return 0;
+}
+
+#endif  // ZYGISKFRIDA_TEST_STUB_ANDROID_LOG_H


### PR DESCRIPTION
Add inject_on_specialize target option for pre-onCreate injection

By default the gadget is loaded on a detached thread that calls
wait_for_init() (busy-wait for the process rename + 100ms), so the dlopen
lands after Application.onCreate. Apps that run anti-tamper checks in
onCreate and latch the verdict therefore decide before a script-mode
gadget's hooks are installed.

The wait only matters for listen-interaction gadgets (which block waiting
for a client) and frida-server discoverability; a script-interaction gadget
just loads its script and returns. Add an optional per-target bool
inject_on_specialize (default false, preserving current behaviour): when
set, check_and_inject() runs inject_libs() synchronously on the Zygisk
specialize thread and inject_libs() skips wait_for_init(), so the dlopen
completes before postAppSpecialize returns -> before handleBindApplication
-> before Application.onCreate.